### PR TITLE
Fix main menu highlighting logic

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -24,10 +24,10 @@
 
       <nav class="site-header__nav">
         <a class="site-header__nav__link{% if prefix == '/news/' %} is-active{% endif %}" href="{{ '/news' | relative_url }}" tabindex="0">News</a>
-        <a class="site-header__nav__link{% if page.url == '/about' %} is-active{% endif %}" href="{{ '/about' | relative_url }}" tabindex="0">About</a>
-        <a class="site-header__nav__link{% if page.url == '/download' %} is-active{% endif %}" href="{{ '/download' | relative_url }}" tabindex="0">Download</a>
-        <a class="site-header__nav__link{% if page.url == '/games' %} is-active{% endif %}" href="{{ '/games' | relative_url }}" tabindex="0">Games</a>
-        <a class="site-header__nav__link{% if page.url == '/community' %} is-active{% endif %}" href="{{ '/community' | relative_url }}" tabindex="0">Community</a>
+        <a class="site-header__nav__link{% if page.url == '/about/' %} is-active{% endif %}" href="{{ '/about' | relative_url }}" tabindex="0">About</a>
+        <a class="site-header__nav__link{% if page.url == '/download/' %} is-active{% endif %}" href="{{ '/download' | relative_url }}" tabindex="0">Download</a>
+        <a class="site-header__nav__link{% if page.url == '/games/' %} is-active{% endif %}" href="{{ '/games' | relative_url }}" tabindex="0">Games</a>
+        <a class="site-header__nav__link{% if page.url == '/community/' %} is-active{% endif %}" href="{{ '/community' | relative_url }}" tabindex="0">Community</a>
         <a class="site-header__nav__link" href="https://forum.openra.net" tabindex="0">
           Forum
           <svg class="icon">


### PR DESCRIPTION
Only the "News" menu item was highlighted as a current page. This PR fixes that by checking for page URLs with a trailing slash.