### PR TITLE
Add trailing slashes to internal links to avoid 301 redirects

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -4,22 +4,22 @@
     <a class="site-footer__logo-link" href="{{ '/' | relative_url }}">
       <img class="site-footer__logo" src="{{ '/images/openra-logo-with-text.svg' | relative_url }}" alt="OpenRA" />
     </a>
-    <div class="site-footer__legal">©2007-{{ site.time | date: '%Y' }} The OpenRA Developers (<a href="{{ '/legal' | relative_url }}">Legal notices</a>)</div>
+    <div class="site-footer__legal">©2007-{{ site.time | date: '%Y' }} The OpenRA Developers (<a href="{{ '/legal/' | relative_url }}">Legal notices</a>)</div>
     <nav class="site-footer__nav">
       <div>
-        <a href="{{ '/news' | relative_url }}" tabindex="0">News</a>
+        <a href="{{ '/news/' | relative_url }}" tabindex="0">News</a>
       </div>
       <div>
-        <a href="{{ '/about' | relative_url }}" tabindex="0">About</a>
+        <a href="{{ '/about/' | relative_url }}" tabindex="0">About</a>
       </div>
       <div>
-        <a href="{{ '/download' | relative_url }}" tabindex="0">Download</a>
+        <a href="{{ '/download/' | relative_url }}" tabindex="0">Download</a>
       </div>
       <div>
-        <a href="{{ '/games' | relative_url }}" tabindex="0">Games</a>
+        <a href="{{ '/games/' | relative_url }}" tabindex="0">Games</a>
       </div>
       <div>
-        <a href="{{ '/community' | relative_url }}" tabindex="0">Community</a>
+        <a href="{{ '/community/' | relative_url }}" tabindex="0">Community</a>
       </div>
       <div>
         <a href="https://forum.openra.net" tabindex="0">

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -23,11 +23,11 @@
       </button>
 
       <nav class="site-header__nav">
-        <a class="site-header__nav__link{% if prefix == '/news/' %} is-active{% endif %}" href="{{ '/news' | relative_url }}" tabindex="0">News</a>
-        <a class="site-header__nav__link{% if page.url == '/about/' %} is-active{% endif %}" href="{{ '/about' | relative_url }}" tabindex="0">About</a>
-        <a class="site-header__nav__link{% if page.url == '/download/' %} is-active{% endif %}" href="{{ '/download' | relative_url }}" tabindex="0">Download</a>
-        <a class="site-header__nav__link{% if page.url == '/games/' %} is-active{% endif %}" href="{{ '/games' | relative_url }}" tabindex="0">Games</a>
-        <a class="site-header__nav__link{% if page.url == '/community/' %} is-active{% endif %}" href="{{ '/community' | relative_url }}" tabindex="0">Community</a>
+        <a class="site-header__nav__link{% if prefix == '/news/' %} is-active{% endif %}" href="{{ '/news/' | relative_url }}" tabindex="0">News</a>
+        <a class="site-header__nav__link{% if page.url == '/about/' %} is-active{% endif %}" href="{{ '/about/' | relative_url }}" tabindex="0">About</a>
+        <a class="site-header__nav__link{% if page.url == '/download/' %} is-active{% endif %}" href="{{ '/download/' | relative_url }}" tabindex="0">Download</a>
+        <a class="site-header__nav__link{% if page.url == '/games/' %} is-active{% endif %}" href="{{ '/games/' | relative_url }}" tabindex="0">Games</a>
+        <a class="site-header__nav__link{% if page.url == '/community/' %} is-active{% endif %}" href="{{ '/community/' | relative_url }}" tabindex="0">Community</a>
         <a class="site-header__nav__link" href="https://forum.openra.net" tabindex="0">
           Forum
           <svg class="icon">

--- a/_layouts/news.html
+++ b/_layouts/news.html
@@ -11,7 +11,7 @@
           <div class="site-section__content">
             <div class="dark-panel">
               <div class="dark-panel__header">
-                <a class="developer-update-detail__view-all" href="{{ '/news' | relative_url }}">
+                <a class="developer-update-detail__view-all" href="{{ '/news/' | relative_url }}">
                   <svg class="icon">
                     <use xlink:href="{{ '/images/icons/icons.svg#icon-chevron-left' | relative_url }}"></use>
                   </svg>

--- a/about.html
+++ b/about.html
@@ -12,7 +12,7 @@ permalink: "/about/"
         <lite-youtube videoid="93b7TKooj-M"></lite-youtube>
         <figcaption>OpenRA's 10th Anniversary Trailer (2017)</figcaption>
       </figure>
-      <p>We’ve developed a flexible game engine (<a href="https://github.com/OpenRA/OpenRA">the OpenRA engine</a>) that provides a common platform for rebuilding and reimagining classic 2D and 2.5D RTS games. The OpenRA engine is not restricted by the technical limitations of the original games. It includes <strong>native support for modern operating systems</strong> (like Windows 10, macOS, and Linux) and screen resolutions without relying on emulation or hacks, and <a href="{{ '/games' | relative_url }}">integrated online multiplayer</a>.</p>
+      <p>We’ve developed a flexible game engine (<a href="https://github.com/OpenRA/OpenRA">the OpenRA engine</a>) that provides a common platform for rebuilding and reimagining classic 2D and 2.5D RTS games. The OpenRA engine is not restricted by the technical limitations of the original games. It includes <strong>native support for modern operating systems</strong> (like Windows 10, macOS, and Linux) and screen resolutions without relying on emulation or hacks, and <a href="{{ '/games/' | relative_url }}">integrated online multiplayer</a>.</p>
       <p><em>EA has not endorsed and does not support this product.</em></p>
     </div>
   </div>

--- a/download.html
+++ b/download.html
@@ -34,7 +34,7 @@ js:
         </div>
         <div class="download-info__license">
           <h3>License and Game Assets</h3>
-          <p>The OpenRA game engine is free software released under the <a href="{{ '/legal#license' | relative_url }}">GPL3 license</a>. The OpenRA mods require files from the original games, which are used under the license granted by the <a href="https://www.ea.com/games/command-and-conquer/command-and-conquer-remastered/modding-faq">C&C Franchise Modding Guidelines</a>. These files are not covered by the OpenRA license, and you will be prompted to download or copy them the first time you run a mod.</p>
+          <p>The OpenRA game engine is free software released under the <a href="{{ '/legal/#license' | relative_url }}">GPL3 license</a>. The OpenRA mods require files from the original games, which are used under the license granted by the <a href="https://www.ea.com/games/command-and-conquer/command-and-conquer-remastered/modding-faq">C&C Franchise Modding Guidelines</a>. These files are not covered by the OpenRA license, and you will be prompted to download or copy them the first time you run a mod.</p>
           <p><em>EA has not endorsed and does not support this product.</em></p>
         </div>
       </div>

--- a/games.html
+++ b/games.html
@@ -109,7 +109,7 @@ js:
       style="width: 100%; height: 300px;">
       Loading...
     </div>
-    <p>More detailed graphs are available at the <a href="{{ '/players' | relative_url }}">player statistics</a> page.</p>
+    <p>More detailed graphs are available at the <a href="{{ '/players/' | relative_url }}">player statistics</a> page.</p>
   </div>
 </section>
 

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@ carousel_items:
         <span class="hero__intro-text__tagline color--gold">Rebuilt for the Modern Era.</span>
       </h1>
       <div class="install">
-        <a class="button button--large button--primary" href="{{ '/download' | relative_url }}">
+        <a class="button button--large button--primary" href="{{ '/download/' | relative_url }}">
           Install Now
           <svg class="button__icon icon">
             <use xlink:href="{{ '/images/icons/icons.svg#icon-download' | relative_url }}"></use>
@@ -112,7 +112,7 @@ carousel_items:
     <div class="dark-panel">
       <div class="dark-panel__header">
         <strong class="text--caps text--medium">Updates from the Developers</strong>
-        <a class="home__developer-updates__view-all" href="{{ '/news' | relative_url }}">[View All Updates]</a>
+        <a class="home__developer-updates__view-all" href="{{ '/news/' | relative_url }}">[View All Updates]</a>
       </div>
       {% for post in site.posts limit:1 %}
         {% include developer-update.html title=post.title author=post.author created_at=post.created_at body=post.content disqus_id=post.disqus_id %}

--- a/legal.html
+++ b/legal.html
@@ -7,7 +7,7 @@ permalink: "/legal/"
   <div class="site-section__content">
     <h1 class="site-section__heading">Legal</h1>
     <img src="{{ '/images/gplv3.svg' | relative_url }}" class="u-float-right" />
-    OpenRA is free software, licenced under the GPL3 license. This means that you are free to do (almost) whatever you wish, as long as you make the source code available for any binary releases you distribute. See the <a href="{{ '/legal#license' | relative_url }}">full GPL 3 licence</a> for more information.
+    OpenRA is free software, licenced under the GPL3 license. This means that you are free to do (almost) whatever you wish, as long as you make the source code available for any binary releases you distribute. See the <a href="{{ '/legal/#license' | relative_url }}">full GPL 3 licence</a> for more information.
     <p>The original game assets are not covered by this license and remain property of Electronic Arts Inc. We provide asset packages based on the freeware releases of these games as a convenience to our players, which we believe falls under the spirit of the <a href="https://www.ea.com/games/command-and-conquer/command-and-conquer-remastered/modding-faq">Command &amp; Conquer&trade; Franchise Modding Guidelines</a>.</p>
     <p>Command & Conquer™ and Command & Conquer: Red Alert™ are trademarks or registered trademarks of Electronic Arts Inc. EA has not endorsed and does not support this product.</p>
   </div>

--- a/license.html
+++ b/license.html
@@ -1,3 +1,3 @@
 ---
-redirect_to: /legal#license
+redirect_to: /legal/#license
 ---

--- a/players.html
+++ b/players.html
@@ -18,7 +18,7 @@ js:
 <section class="site-section">
   <div class="site-section__content">
     <h1 class="site-section__heading">Player Statistics</h1>
-    <p>The following plots show the average number of players active in publically advertised servers over various time ranges. They are generated from the <a href="{{ '/games' | relative_url }}">real-time games list</a>.</p>
+    <p>The following plots show the average number of players active in publically advertised servers over various time ranges. They are generated from the <a href="{{ '/games/' | relative_url }}">real-time games list</a>.</p>
   </div>
 </section>
 


### PR DESCRIPTION
All internal urls are redirected to a version with a trailing slash however the links pointing to them don't have a slash. This causes a 301 redirect to occur which should be avoided. 

Clicking on a menu link before this PR:
![image](https://user-images.githubusercontent.com/1355810/119975427-81f5e780-bfbe-11eb-91f3-57d2cb634550.png)

And after:
![image](https://user-images.githubusercontent.com/1355810/119975254-478c4a80-bfbe-11eb-8f9c-eb2898221fc4.png)

Depends on #14 
