### PR TITLE
Add titles to pages and print them in the head

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,4 +1,5 @@
 ---
+title: "Page Not Found"
 permalink: /404.html
 ---
 

--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,11 @@
 # General configuration
 url: "https://www.openra.net"
 baseurl: ""
+title: OpenRA
+description: >-
+  OpenRA is an open source project that recreates and modernizes classic real time strategy games, like Red Alert, Command & Conquer, and Dune 2000.
+tagline: >-
+  Classic strategy games rebuilt for the modern era
 twitter_username: OpenRA
 github_username: OpenRA
 permalink: /:categories/:title/index.html
@@ -28,10 +33,6 @@ plugins:
   - jekyll-github-metadata
 
 # jekyll-feed configuration
-title: OpenRA - News Feed 
-description: >- # this means to ignore newlines until "baseurl:"
-  Classic strategy games rebuilt for the modern era
-
 feed:
   path: /news/atom/index.xml
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -19,7 +19,14 @@
   <!-- query param at the end is for cache busting if/when more dynamic social images are added -->
   <meta name="twitter:image" content="{{ '/images/social.jpg' | relative_url }}?t={{ site.time | date: "%Y-%m-%d-%H-%M" }}">
 
-  <title>OpenRA - Classic strategy games rebuilt for the modern era</title>
+  {% capture page_title %}
+    {% if page.title %}
+      {{ page.title }} | {{ site.title }}
+    {% else %}
+      {{ site.title }} - {{ site.tagline }}
+    {% endif %}
+  {% endcapture %}
+  <title>{{ page_title | strip }}</title>
   <link rel="stylesheet" href="{{ '/styles/normalize.css' | relative_url }}" />
   <link rel="stylesheet" href="{{ '/styles/index.css' | relative_url }}" />
   <link rel="stylesheet" href="{{ '/styles/lite-youtube-embed.css' | relative_url }}" />

--- a/about.html
+++ b/about.html
@@ -1,4 +1,5 @@
 ---
+title: "About"
 permalink: "/about/"
 ---
 

--- a/community.html
+++ b/community.html
@@ -1,4 +1,5 @@
 ---
+title: "Community"
 permalink: "/community/"
 ---
 

--- a/download.html
+++ b/download.html
@@ -1,4 +1,5 @@
 ---
+title: "Download"
 permalink: "/download/"
 js:
 - /scripts/download.js

--- a/games.html
+++ b/games.html
@@ -1,4 +1,5 @@
 ---
+title: "Server Browser"
 permalink: "/games/"
 js:
 - /scripts/vendor/popper.js

--- a/legal.html
+++ b/legal.html
@@ -1,4 +1,5 @@
 ---
+title: "Legal"
 permalink: "/legal/"
 ---
 

--- a/news/index.html
+++ b/news/index.html
@@ -1,4 +1,5 @@
 ---
+title: "News Archive"
 layout: "default"
 ---
 

--- a/players.html
+++ b/players.html
@@ -1,4 +1,5 @@
 ---
+title: "Player Statistics"
 permalink: "/players/"
 js:
 - /scripts/server-browser.js


### PR DESCRIPTION
This also changes and moves the global `site.title` and `site.description` variables. These variables are intended for use as global site properties and should not be limited to just the feed.

Closes #7 