### PR TITLE
Fix some issues with OG tags for social sharing

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,7 +6,7 @@ description: >-
   OpenRA is an open source project that recreates and modernizes classic real time strategy games, like Red Alert, Command & Conquer, and Dune 2000.
 tagline: >-
   Classic strategy games rebuilt for the modern era
-twitter_username: OpenRA
+twitter_username: openRA
 github_username: OpenRA
 permalink: /:categories/:title/index.html
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -3,10 +3,17 @@
   <meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no" />
   <meta name="description" content="{{ site.description }}" />
 
+  {% capture social_title %}
+    {% if page.title %}
+      {{ page.title }} | {{ site.title }}
+    {% else %}
+      {{ site.title }}
+    {% endif %}
+  {% endcapture %}
   <!-- OpenGraph -->
-  <meta property="og:title" content="OpenRA" />
+  <meta property="og:title" content="{{ social_title | strip }}" />
   <meta property="og:type" content="website" />
-  <meta property="og:description" content="{{ site.description }}" />
+  <meta property="og:description" content="{{ site.tagline }}" />
   <meta property="og:url" content="{{ page.url | absolute_url }}" />
   <!-- query param at the end is for cache busting if/when more dynamic social images are added -->
   <meta property="og:image" content="{{ '/images/social.jpg' | absolute_url }}?t={{ site.time | date: "%Y-%m-%d-%H-%M" }}" />
@@ -14,8 +21,8 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@{{ site.twitter_username }}">
   <meta name="twitter:creator" content="@{{ site.twitter_username }}">
-  <meta name="twitter:title" content="OpenRA">
-  <meta name="twitter:description" content="{{ site.description }}">
+  <meta name="twitter:title" content="{{ social_title | strip }}">
+  <meta name="twitter:description" content="{{ site.tagline }}">
   <!-- query param at the end is for cache busting if/when more dynamic social images are added -->
   <meta name="twitter:image" content="{{ '/images/social.jpg' | absolute_url }}?t={{ site.time | date: "%Y-%m-%d-%H-%M" }}">
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -9,7 +9,7 @@
   <meta property="og:description" content="{{ site.description }}" />
   <meta property="og:url" content="{{ site.url }}" />
   <!-- query param at the end is for cache busting if/when more dynamic social images are added -->
-  <meta property="og:image" content="{{ '/images/social.jpg' | relative_url }}?t={{ site.time | date: "%Y-%m-%d-%H-%M" }}" />
+  <meta property="og:image" content="{{ '/images/social.jpg' | absolute_url }}?t={{ site.time | date: "%Y-%m-%d-%H-%M" }}" />
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@openRA">
@@ -17,7 +17,7 @@
   <meta name="twitter:title" content="OpenRA">
   <meta name="twitter:description" content="{{ site.description }}">
   <!-- query param at the end is for cache busting if/when more dynamic social images are added -->
-  <meta name="twitter:image" content="{{ '/images/social.jpg' | relative_url }}?t={{ site.time | date: "%Y-%m-%d-%H-%M" }}">
+  <meta name="twitter:image" content="{{ '/images/social.jpg' | absolute_url }}?t={{ site.time | date: "%Y-%m-%d-%H-%M" }}">
 
   {% capture page_title %}
     {% if page.title %}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -34,6 +34,9 @@
     {% endif %}
   {% endcapture %}
   <title>{{ page_title | strip }}</title>
+
+  <link rel="canonical" href="{{ page.url | absolute_url }}" />
+
   <link rel="stylesheet" href="{{ '/styles/normalize.css' | relative_url }}" />
   <link rel="stylesheet" href="{{ '/styles/index.css' | relative_url }}" />
   <link rel="stylesheet" href="{{ '/styles/lite-youtube-embed.css' | relative_url }}" />

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -7,7 +7,7 @@
   <meta property="og:title" content="OpenRA" />
   <meta property="og:type" content="website" />
   <meta property="og:description" content="{{ site.description }}" />
-  <meta property="og:url" content="{{ site.url }}" />
+  <meta property="og:url" content="{{ page.url | absolute_url }}" />
   <!-- query param at the end is for cache busting if/when more dynamic social images are added -->
   <meta property="og:image" content="{{ '/images/social.jpg' | absolute_url }}?t={{ site.time | date: "%Y-%m-%d-%H-%M" }}" />
   <!-- Twitter -->

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -12,8 +12,8 @@
   <meta property="og:image" content="{{ '/images/social.jpg' | absolute_url }}?t={{ site.time | date: "%Y-%m-%d-%H-%M" }}" />
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:site" content="@openRA">
-  <meta name="twitter:creator" content="@openRA">
+  <meta name="twitter:site" content="@{{ site.twitter_username }}">
+  <meta name="twitter:creator" content="@{{ site.twitter_username }}">
   <meta name="twitter:title" content="OpenRA">
   <meta name="twitter:description" content="{{ site.description }}">
   <!-- query param at the end is for cache busting if/when more dynamic social images are added -->

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -21,10 +21,6 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@{{ site.twitter_username }}">
   <meta name="twitter:creator" content="@{{ site.twitter_username }}">
-  <meta name="twitter:title" content="{{ social_title | strip }}">
-  <meta name="twitter:description" content="{{ site.tagline }}">
-  <!-- query param at the end is for cache busting if/when more dynamic social images are added -->
-  <meta name="twitter:image" content="{{ '/images/social.jpg' | absolute_url }}?t={{ site.time | date: "%Y-%m-%d-%H-%M" }}">
 
   {% capture page_title %}
     {% if page.title %}


### PR DESCRIPTION
The commit messages explain what I did here in detail but the basic idea is to print meta data for the current page instead of the same data for the whole site. This is a problem because if for example a news article is shared on FB it will display the title of the site and link to the homepage. This can be seen in the FB debugger:
![image](https://user-images.githubusercontent.com/1355810/119989469-e1a8be80-bfcf-11eb-9667-64c78b2bfe86.png)

I also fixed the social image by using an absolute url and I added a canonical meta tag (for SEO).

Depends on #16 