### PR TITLE
Install bundler version 2.3.26 in the deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
         env:
           JEKYLL_GITHUB_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
         run: |
-          sudo gem install bundler
+          sudo gem install bundler -v 2.3.26
           bundle install
           bundle exec jekyll build
 


### PR DESCRIPTION
Apparently there is a new version (2.4.0) of bundler now which causes our deploy workflow to fail: https://github.com/OpenRA/OpenRAWebsiteV3/actions/runs/3771456712/jobs/6411894401
Explicitly installing the previous version (2.3.26) works again: https://github.com/OpenRA/OpenRAWebsiteV3/actions/runs/3771513390