### PR TITLE
Fixed license link

### DIFF
--- a/download.html
+++ b/download.html
@@ -34,7 +34,7 @@ js:
         </div>
         <div class="download-info__license">
           <h3>License and Game Assets</h3>
-          <p>The OpenRA game engine is free software released under the <a href="{{ '/legal/#license' | relative_url }}">GPL3 license</a>. The OpenRA mods require files from the original games, which are used under the license granted by the <a href="https://www.ea.com/games/command-and-conquer/command-and-conquer-remastered/modding-faq">C&C Franchise Modding Guidelines</a>. These files are not covered by the OpenRA license, and you will be prompted to download or copy them the first time you run a mod.</p>
+          <p>The OpenRA game engine is free software released under the <a href="https://github.com/OpenRA/OpenRA/blob/bleed/COPYING">GPL3 license</a>. The OpenRA mods require files from the original games, which are used under the license granted by the <a href="https://www.ea.com/games/command-and-conquer/command-and-conquer-remastered/modding-faq">C&C Franchise Modding Guidelines</a>. These files are not covered by the OpenRA license, and you will be prompted to download or copy them the first time you run a mod.</p>
           <p><em>EA has not endorsed and does not support this product.</em></p>
         </div>
       </div>


### PR DESCRIPTION
https://www.openra.net/legal/#license is a placeholder leading nowhere.