### PR TITLE
Add mirror lists for D2k V3 (R16) content.

### DIFF
--- a/packages/d2k-base-v3-mirrors.txt
+++ b/packages/d2k-base-v3-mirrors.txt
@@ -1,0 +1,2 @@
+http://openra.baxxster.no/openra/d2k-v3/d2k-base-v3.zip
+http://openra.mirror.haffdata.com/d2k-base-v3.zip

--- a/packages/d2k-patch106-v3-mirrors.txt
+++ b/packages/d2k-patch106-v3-mirrors.txt
@@ -1,0 +1,2 @@
+http://openra.baxxster.no/openra/d2k-v3/d2k-patch106-v3.zip
+http://openra.mirror.haffdata.com/d2k-patch106-v3.zip

--- a/packages/d2k-quickinstall-v3-mirrors.txt
+++ b/packages/d2k-quickinstall-v3-mirrors.txt
@@ -1,0 +1,2 @@
+http://openra.baxxster.no/openra/d2k-v3/d2k-quickinstall-v3.zip
+http://openra.mirror.haffdata.com/d2k-quickinstall-v3.zip


### PR DESCRIPTION
This PR adds mirror lists for the higher-quality R16 assets that we will hopefully soon switch OpenRA's D2k to use.
~~These are currently empty because we don't yet have any mirrors. I will update these as they are added.~~

Ping @Baxxster @anderson2927 @alberthaff: could you please add the following three files to your respective mirrors?

[d2k-patch106-v3.zip](https://github.com/OpenRA/OpenRAWebsiteV3/files/13539253/d2k-patch106-v3.zip)
[d2k-base-v3.zip](https://github.com/OpenRA/OpenRAWebsiteV3/files/13539255/d2k-base-v3.zip)
[d2k-quickinstall-v3.zip](https://github.com/OpenRA/OpenRAWebsiteV3/files/13539259/d2k-quickinstall-v3.zip)
