### PR TITLE
Remove openSUSE Linux

### DIFF
--- a/download.html
+++ b/download.html
@@ -270,17 +270,6 @@ js:
                     <code class="terminal"><span class="terminal__prompt">$</span> pacman -S openra</code>
                   </p>
                 </dd>
-
-                <dt>
-                  <img src="{{ '/images/icons/linux-mirrors/opensuse.svg' | relative_url }}" class="icon" />
-                  openSUSE Linux
-                </dt>
-                <dd>
-                  Stable releases and playtests are available via the <a href="http://software.opensuse.org/download.html?project=games:openra&amp;package=openra">openSUSE Build Service repository</a>.
-                  <p>
-                    <code class="terminal"><span class="terminal__prompt">$</span> zypper install openra</code>
-                  </p>
-                </dd>
         
                 <dt>
                   <img class="icon" src="{{ '/images/icons/linux-mirrors/solus.svg' | relative_url }}" />


### PR DESCRIPTION
https://software.opensuse.org/download.html?project=games:openra&package=openra

Last release openra-20161001-2.1

cleanly removed

<img width="1026" alt="Screenshot 2025-03-29 at 17 49 18" src="https://github.com/user-attachments/assets/02355f99-10a2-414a-9eb4-eb05cf6fba5d" />
