### PR TITLE
Remove FreeBSD

### DIFF
--- a/_sass/pages/download.scss
+++ b/_sass/pages/download.scss
@@ -29,10 +29,6 @@
   color: $color-linux;
 }
 
-.download__os-free-bsd .icon {
-  color: $color-freebsd;
-}
-
 .download__content {
 }
 

--- a/_sass/variables.scss
+++ b/_sass/variables.scss
@@ -13,7 +13,6 @@ $color-info: rgb(133, 201, 255);
 $color-windows: rgb(0, 173, 239);
 $color-macos: rgb(200, 200, 200);
 $color-linux: rgb(239, 176, 2);
-$color-freebsd: rgb(219, 32, 0);
 
 $color-red-alert: rgb(255, 17, 17);
 $color-command-and-conquer: rgb(255, 199, 0);

--- a/download.html
+++ b/download.html
@@ -88,19 +88,6 @@ js:
             value="linux"
             type="radio" />
         </label>
-        <label class="radio-button radio-button--icon button download__os download__os-free-bsd">
-          <svg class="button__icon icon">
-            <use xlink:href="{{ '/images/icons/icons.svg#icon-freebsd' | relative_url }}"></use>
-          </svg>
-          <div>
-            FreeBSD
-          </div>
-          <input
-            class="radio-button__input"
-            name="operating-system"
-            value="free-bsd"
-            type="radio" />
-        </label>
         <label class="radio-button radio-button--icon download__os-source button">
           <svg class="button__icon icon">
             <use xlink:href="{{ '/images/icons/icons.svg#icon-github' | relative_url }}"></use>
@@ -317,19 +304,7 @@ js:
               </dl>
             </div>
           </div>
-      
-          <div id="free-bsd-instructions" class="instruction dark-panel">
-            <div class="instruction__content">
-              Stable releases are available in the <a href="https://www.freshports.org/games/openra/">FreeBSD Ports Collection</a>:
-              <p>
-<code class="terminal"><span class="terminal__prompt">#</span> cd /usr/ports/games/openra
-<span class="terminal__prompt">#</span> make install</code>
-              </p>
-              <p class="text--warning text--small">We do not maintain this external package source, so there may be delays when a new version is released. Please contact the downstream repository maintainers about any packaging issues.
-              </p>
-            </div>
-          </div>
-      
+
           <div id="source-instructions" class="instruction dark-panel">
             <div class="instruction__content">
               OpenRA can be compiled from source on all platforms.

--- a/scripts/download.js
+++ b/scripts/download.js
@@ -20,7 +20,6 @@
     let os;
     if (navigator.appVersion.indexOf('Win') !== -1) os = 'windows'; 
     if (navigator.appVersion.indexOf('Mac') !== -1) os = 'macos'; 
-    if (navigator.appVersion.indexOf('FreeBSD') !== -1) os = 'free-bsd'; 
     if (navigator.appVersion.indexOf('Linux') !== -1) os = 'linux'; 
 
     return os;


### PR DESCRIPTION
https://www.freshports.org/games/openra/

FreeBSD maintainer is no longer active

<img width="682" alt="Screenshot_2025-03-29_at_17 55 40" src="https://github.com/user-attachments/assets/c5e5f58c-eeca-426a-93be-4dc88161544d" />

We are dropping support for FreeBSD in the codebase for next release as well

<img width="513" alt="Screenshot 2025-03-29 at 18 04 03" src="https://github.com/user-attachments/assets/7a88b86d-29ae-4059-b125-78a804820660" />
