### PR TITLE
Fix small typo in windows winget instructions

### DIFF
--- a/download.html
+++ b/download.html
@@ -128,7 +128,7 @@ js:
               </p>
               <p>Stable releases are also available from <a href="https://winstall.app/apps/OpenRA.OpenRA">WinGet</a>:</p>
               <p>
-                <code class="terminal"><span class="terminal__prompt">></span> winget install openra</code>
+                <code class="terminal"><span class="terminal__prompt">></span> winget install --id OpenRa.OpenRa.Release</code>
               </p>
               <p>Packages are also available from <a href="https://community.chocolatey.org/packages/openra">Chocolatey</a>:</p>
               <p>


### PR DESCRIPTION
`winget install openra`
asks for clarification between either
- OpenRA.OpenRA.Playtest
or
- OpenRA.OpenRA.Release